### PR TITLE
Remove puppetlabs-stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,9 +7,7 @@
   "source": "https://github.com/dskad/puppet-supervisor_provider",
   "project_page": "https://github.com/dskad/puppet-supervisor_provider",
   "issues_url": "https://github.com/dskad/puppet-supervisor_provider/issues",
-  "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
-  ],
+  "dependencies": [],
   "operatingsystem_support": [
    {
      "operatingsystem": "RedHat",


### PR DESCRIPTION
All the code is in Ruby! Why did I leave this in here?
