### PR TITLE
supervisorctl avail doesn't use process/group name

### DIFF
--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   def enabled?
     supervisorctl(:reread)
     output = supervisorctl(:avail)
-    if match = output.scan(/#{resource[:name]}\s+(in use)/i)[0]
+    if output =~ /#{resource[:name]}\s+(in use)/i
       return :true
     end
     return :false

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -20,8 +20,8 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   end
 
   def enabled?
-    output = supervisorctl(:avail, @resource[:name])
-    if match = output.scan(/\S+\s+(in use|avail)/i)[0]
+    output = supervisorctl(:avail)
+    if match = output.scan(/#{resource[:name]}\s+(in use|avail)/i)[0]
       case match.to_s
       when /in use/i
         return :true

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -73,7 +73,12 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   end
 
   def restart
-    output = supervisorctl(:restart, @resource[:name])
+    reread_output = supervisorctl(:reread)
+    if reread_output =~ /#{resource[:name]}:\s+(changed)/i
+      output = supervisorctl(:update, @resource[:name])
+    else
+      output = supervisorctl(:restart, @resource[:name])
+    end
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not restart #{self.name}: #{output}"
   end

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -9,6 +9,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   def self.instances
     # avail subcommand returns 'in use' for enabled and 'avail' for disabled
     i = []
+    supervisorctl(:reread)
     output = supervisorctl(:avail)
     output.scan(/^(\S+)\s+(in use|avail)/i).each do |m|
       i << new(:name => m[0])
@@ -20,6 +21,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   end
 
   def enabled?
+    supervisorctl(:reread)
     output = supervisorctl(:avail)
     if match = output.scan(/#{resource[:name]}\s+(in use)/i)[0]
       return :true

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -21,15 +21,8 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
 
   def enabled?
     output = supervisorctl(:avail)
-    if match = output.scan(/#{resource[:name]}\s+(in use|avail)/i)[0]
-      case match.to_s
-      when /in use/i
-        return :true
-      when /avail/i
-        return :false
-      else
-        return :false
-      end
+    if match = output.scan(/#{resource[:name]}\s+(in use)/i)[0]
+      return :true
     end
     return :false
   rescue Puppet::ExecutionFailure


### PR DESCRIPTION
`supervisorctl avail` will always print a list of all known process groups and their status, so passing the `@resource[:name]` parameter to it doesn't have any effect. Instead, we can include the parameter in the regex being used, so we can use the output for that specific process group. 

The result of not including the parameter in the regex is that the regex will match to the first line of output from the `supervisorctl avail` command. As this may vary when using supervisor to control multiple processes, the result is unpredictable. 

_In my case (tested using supervisor 3.3.1), this resulted in a service 'enabled' state being switched to 'true' on every puppet run, even though it's status didn't change. e.g. `Service[process-name]/enable: enable changed 'false' to 'true'`_

_Edit: Applied this change in second commit:_
The code could probably also be simplified a bit. Since `enabled` is only true when the regex matches 'in use', we don't really need to check for other cases like 'avail' and we could return `true` right away.

Edit2: 
- Added missing `reread` commands before using `avail`. This caused new services not being started by supervisor, even though puppet implied that they were.
- Added `reread` command and check before restarting the process to see if the supervisor configuration file changed. If it did, we now run `update <process>` instead of `restart <process>`. This will make sure configuration changes are being taken into account.
- Simplified regex match when we don't need the capture groups as an array.