### PR TITLE
add support for restart attribute

### DIFF
--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   def restart
     reread_output = supervisorctl(:reread)
     if @resource[:restart]
-      output = %x[#{resource[:restart]}]
+      output = %x["#{resource[:restart]}"]
     else
       if reread_output =~ /#{resource[:name]}:\s+(changed)/i
         output = supervisorctl(:update, @resource[:name])

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   def restart
     reread_output = supervisorctl(:reread)
     if @resource[:restart]
-      output = %x["#{resource[:restart]}"]
+      output = `#{resource[:restart]}`
     else
       if reread_output =~ /#{resource[:name]}:\s+(changed)/i
         output = supervisorctl(:update, @resource[:name])
@@ -86,5 +86,4 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not restart #{self.name}: #{output}"
   end
-
 end

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -73,16 +73,17 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   end
 
   def restart
+    reread_output = supervisorctl(:reread)
     if @resource[:restart]
       output = `#{resource[:restart]}`
     else
-      reread_output = supervisorctl(:reread)
       if reread_output =~ /#{resource[:name]}:\s+(changed)/i
         output = supervisorctl(:update, @resource[:name])
       else
         output = supervisorctl(:restart, @resource[:name])
       end
-    end  rescue Puppet::ExecutionFailure
+    end
+  rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not restart #{self.name}: #{output}"
   end
 

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -75,7 +75,7 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   def restart
     reread_output = supervisorctl(:reread)
     if @resource[:restart]
-      output = `#{resource[:restart]}`
+      output = %x[#{resource[:restart]}]
     else
       if reread_output =~ /#{resource[:name]}:\s+(changed)/i
         output = supervisorctl(:update, @resource[:name])

--- a/lib/puppet/provider/service/supervisor.rb
+++ b/lib/puppet/provider/service/supervisor.rb
@@ -73,13 +73,16 @@ Puppet::Type.type(:service).provide(:supervisor, :parent => :base) do
   end
 
   def restart
-    reread_output = supervisorctl(:reread)
-    if reread_output =~ /#{resource[:name]}:\s+(changed)/i
-      output = supervisorctl(:update, @resource[:name])
+    if @resource[:restart]
+      output = `#{resource[:restart]}`
     else
-      output = supervisorctl(:restart, @resource[:name])
-    end
-  rescue Puppet::ExecutionFailure
+      reread_output = supervisorctl(:reread)
+      if reread_output =~ /#{resource[:name]}:\s+(changed)/i
+        output = supervisorctl(:update, @resource[:name])
+      else
+        output = supervisorctl(:restart, @resource[:name])
+      end
+    end  rescue Puppet::ExecutionFailure
     raise Puppet::Error, "Could not restart #{self.name}: #{output}"
   end
 


### PR DESCRIPTION
I've added support for the restart attribute of puppet service resource:

https://docs.puppet.com/puppet/latest/types/service.html#service-attribute-restart

**restart**

Specify a restart command manually. If left unspecified, the service will be stopped and then started.